### PR TITLE
Reuse QueryInfo#stop method instead of adding a destroy method.

### DIFF
--- a/src/core/QueryManager.ts
+++ b/src/core/QueryManager.ts
@@ -665,7 +665,7 @@ export class QueryManager<TStore> {
     // A query created with `QueryManager.query()` could trigger a `QueryManager.fetchRequest`.
     // The same queryId could have two rejection fns for two promises
     this.fetchCancelFns.delete(queryId);
-    this.getQuery(queryId).destroy();
+    this.getQuery(queryId).stop();
     this.queries.delete(queryId);
   }
 


### PR DESCRIPTION
@salper This is a friendly counter-PR onto your PR https://github.com/apollographql/apollo-client/pull/7278, with an extra commit that reflects my feedback.

Your "naive take" was pretty much correct, but I took the liberty of reusing the existing `QueryInfo#stop` method instead of introducing a new `destroy` method. Does this look good to you?

If you merge this PR, my commit will show up over at https://github.com/apollographql/apollo-client/pull/7278, though I would suggest rebasing against the latest `apollographql/main` branch so it's easier to merge your original PR. Alternatively, if you don't mind, you can open up your fork so I can force-push to it. I think that option should be somewhere in the right-hand column of https://github.com/apollographql/apollo-client/pull/7278.

Thanks for your patience!